### PR TITLE
Use GSON field naming policy

### DIFF
--- a/src/main/java/com/battlesnake/game/snake/Head.java
+++ b/src/main/java/com/battlesnake/game/snake/Head.java
@@ -6,17 +6,14 @@ import com.google.gson.annotations.SerializedName;
  * @author Tony
  */
 public enum Head {
-    bendr,
-    dead,
-    fang,
-    pixel,
-    regular,
-    safe,
-
-    @SerializedName("sand-worm")
-    sandWorm,
-
-    shades,
-    smile,
-    tongue;
+    BENDR,
+    DEAD,
+    FANG,
+    PIXEL,
+    REGULAR,
+    SAFE,
+    SAND_WORM,
+    SHADES,
+    SMILE,
+    TONGUE;
 }

--- a/src/main/java/com/battlesnake/game/snake/SnakeConfig.java
+++ b/src/main/java/com/battlesnake/game/snake/SnakeConfig.java
@@ -14,23 +14,15 @@ public class SnakeConfig extends JsonObject {
     private static final String NAME = "Liquid Snake";
     private static final String IMAGE = "https://i.imgur.com/TGNk0gd.png";
     private static final String START_TAUNT = "Sleeping late as usual, ...eh Snake?";
-    private static final Head HEAD_TYPE = Head.shades;
-    private static final Tail TAIL_TYPE = Tail.skinny;
+    private static final Head HEAD_TYPE = Head.SHADES;
+    private static final Tail TAIL_TYPE = Tail.SKINNY;
 
     private String name;
     private String color;
     private String taunt;
-
-    @SerializedName("head_type")
     private Head headType;
-
-    @SerializedName("head_url")
     private String headUrl;
-
-    @SerializedName("secondary_color")
     private String secondaryColor;
-
-    @SerializedName("tail_type")
     private Tail tailType;
 
     public SnakeConfig() {

--- a/src/main/java/com/battlesnake/game/snake/Tail.java
+++ b/src/main/java/com/battlesnake/game/snake/Tail.java
@@ -6,23 +6,13 @@ import com.google.gson.annotations.SerializedName;
  * @author Tony
  */
 public enum Tail {
-    @SerializedName("block-bum")
-    blockBum,
-
-    curled,
-
-    @SerializedName("fat-rattle")
-    fatRattle,
-
-    freckled,
-    pixel,
-    regular,
-
-    @SerializedName("round-bum")
-    roundBum,
-
-    skinny,
-
-    @SerializedName("small-rattle")
-    smallRattle;
+    BLOCK_BUM,
+    CURLED,
+    FAT_RATTLE,
+    FRECKLED,
+    PIXEL,
+    REGULAR,
+    ROUND_BUM,
+    SKINNY,
+    SMALL_RATTLE;
 }

--- a/src/main/java/com/battlesnake/serialization/JsonObject.java
+++ b/src/main/java/com/battlesnake/serialization/JsonObject.java
@@ -3,11 +3,13 @@ package com.battlesnake.serialization;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.interceptors.InterceptorFactory;
+import com.google.gson.FieldNamingPolicy;
 
 public abstract class JsonObject {
 
     protected Gson gson() {
         return new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .registerTypeAdapterFactory(new InterceptorFactory())
             .create();
     }


### PR DESCRIPTION
Uses a GSON field naming policy to handle serialization to `snake_case`.

Prior to this commit, this was done using the `@SerializedName` annotation.