### PR TITLE
Add support for Heroku Gradle task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -jar build/server/webapp-runner-*.jar build/libs/*.war

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ ext {
     gsonVersion = '2.8.5'
     junitVersion = '4.12'
     servletVersion = '4.0.1'
+    webappRunnerVersion = '8.5.11.3'
 }
 
 repositories {
@@ -30,5 +31,20 @@ dependencies {
     compile "com.google.code.gson:gson:$gsonVersion"
     compile "com.google.code.gson:gson-extras:$gsonVersion"
     compile "javax.servlet:javax.servlet-api:$servletVersion"
+    compile "com.github.jsimone:webapp-runner:$webappRunnerVersion"
     testCompile "junit:junit:$junitVersion"
 }
+
+task stage() {
+    dependsOn clean, war
+}
+war.mustRunAfter clean
+
+task copyToLib(type: Copy) {
+    into "$buildDir/server"
+    from(configurations.compile) {
+        include "webapp-runner*"
+    }
+}
+
+stage.dependsOn(copyToLib)

--- a/src/main/java/com/battlesnake/game/snake/#SnakeConfig.java#
+++ b/src/main/java/com/battlesnake/game/snake/#SnakeConfig.java#
@@ -1,0 +1,46 @@
+package com.battlesnake.game.snake;
+
+import com.battlesnake.serialization.JsonObject;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * A standard response to a start request.
+ *
+ * @author Tony
+ */
+public class SnakeConfig extends JsonObject {
+
+    private static final String COLOR = "#f2c55c";
+    private static final String NAME = "Liquid Snake";
+    private static final String IMAGE = "https://i.imgur.com/FX5ZLYE.png";
+    private static final String START_TAUNT = "Sleeping late as usual, ...eh Snake?";
+    private static final Head HEAD_TYPE = Head.shades;
+    private static final Tail TAIL_TYPE = Tail.skinny;
+
+    private String color;
+
+    @SerializedName("head_type")
+    private Head headType;
+
+    @SerializedName("head_url")
+    private String headUrl;
+
+    private String name;
+
+    @SerializedName("secondary_color")
+    private String secondaryColor;
+
+    @SerializedName("tail_type")
+    private Tail tailType;
+
+    private String taunt;
+
+    public SnakeConfig() {
+        this.name = NAME;
+        this.color = COLOR;
+        this.image IMAGE);
+        setTaunt(START_TAUNT);
+        setTailType(TAIL_TYPE);
+        setHeadType(HEAD_TYPE);
+    }
+}


### PR DESCRIPTION
Enables the Gradle `stage` task used by Heroku.

This builds and runs the Java `WAR` file using the Tomcat based `Webapp Runner` `JAR`