### PR TITLE
Add package info to manifest file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,32 @@
 apply plugin: 'java'
 apply plugin: 'war'
 
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 group = 'com.battlesnakes'
 description = "Battlesnake"
-version = '1.0.0'
+version = getVersionName()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 war {
     archiveName = rootProject.name + '.war'
+    doFirst {
+        manifest {
+            attributes("Implementation-Title": project.name,
+                       "Implementation-Version": version,
+                       "Implementation-Timestamp": new Date()
+            )
+        }
+    }
 }
 war.mustRunAfter clean
 


### PR DESCRIPTION
Adds title, version and time created to the `MANIFEST.MF` file in the `WAR`.

The version number is retrieved from the latest Git tag,
including the commit hash and the number of commits since that tag.

Version number is computed using `git describe --tags`.