### PR TITLE
Add port to procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar build/server/webapp-runner-*.jar build/libs/*.war
+web: java $JAVA_OPTS -jar build/server/webapp-runner-*.jar ${WEBAPP_RUNNER_OPTS} --port $PORT build/libs/*.war


### PR DESCRIPTION
Adds the port environment variable to the procfile to ensure Heroku deployments work.