### PR TITLE
Use Heroku environment variables to form version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'war'
 def getVersionName = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
+        commandLine 'sh', './version.sh'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+VERSION=$(git describe --tags)
+
+if [ $? -eq 0 ]; then
+    echo $VERSION
+else
+    echo $HEROKU_RELEASE_VERSION-$HEROKU_SLUG_COMMIT
+fi


### PR DESCRIPTION
Uses Heroku environment variables when needed to form the version.

This is needed since Heroku does not clone the Git repo with the `.git` folder.
As a result any Git commands can not be used to discover the version.