### PR TITLE
Resolve ternary operator precedence

### DIFF
--- a/src/main/java/com/battlesnake/game/Board.java
+++ b/src/main/java/com/battlesnake/game/Board.java
@@ -202,7 +202,7 @@ public class Board {
 
     private boolean movable(Point point, boolean excludeDanger) {
         return !isFilled(point)
-            && excludeDanger ? !isFakeWall(point) : true;
+            && (excludeDanger ? !isFakeWall(point) : true);
     }
 
     public Move goToAttack(Point currentPoint) {


### PR DESCRIPTION
Resolves an issue where the ternary operator was
occurring in the incorrect order, resulting in the snake
ignoring walls.

Resolve #16