### PR TITLE
Prevent safety walls from overriding other snakes

### DIFF
--- a/src/main/java/com/battlesnake/game/Board.java
+++ b/src/main/java/com/battlesnake/game/Board.java
@@ -309,7 +309,10 @@ public class Board {
                     List<Point> around = findAdjacent(head);
                     for (Point point : around) {
                         if (exists(point)) {
-                            board[point.getX()][point.getY()] = FAKE_WALL;
+                            if (board[point.getX()][point.getY()] == EMPTY
+                             || board[point.getX()][point.getY()] == FOOD) {
+                                board[point.getX()][point.getY()] = FAKE_WALL;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Prior to this commit, fake walls could be placed
over other snakes causing some methods to ignore the snake being
there.

Resolve #51