### PR TITLE
Obtain snake length from body size

### DIFF
--- a/src/main/java/com/battlesnake/game/snake/Snake.java
+++ b/src/main/java/com/battlesnake/game/snake/Snake.java
@@ -33,7 +33,6 @@ public class Snake {
     private List<Point> body;
     private int health;
     private String id;
-    private int length;
     private String name;
 
     private transient String taunt;
@@ -81,7 +80,7 @@ public class Snake {
     }
 
     public int length() {
-        return length;
+        return body.size();
     }
 
     private boolean longerThan(int length) {


### PR DESCRIPTION
In the 2019 Battlesnake API, the length property no longer exists.

This resulted in the length property not being serialized,
causing each snake to think they have a length of `0`.

This in-turn made the snake behave as if
every other snake had the same length.

Resolve #53