### PR TITLE
Correctly convert underscore enum values to hyphen

### DIFF
--- a/src/main/java/com/battlesnake/serialization/LowercaseEnumTypeAdapterFactory.java
+++ b/src/main/java/com/battlesnake/serialization/LowercaseEnumTypeAdapterFactory.java
@@ -55,6 +55,6 @@ public final class LowercaseEnumTypeAdapterFactory
     }
 
     private String toLowercase(Object object) {
-        return object.toString().toLowerCase(Locale.US);
+        return object.toString().toLowerCase(Locale.US).replaceAll("_", "-");
     }
 }


### PR DESCRIPTION
Converts underscore enum values to be hyphenated to match snake case.  eg. `small_rattle` to `small-rattle`.